### PR TITLE
[HADOOP-16267] Change replaceAll() to replace

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/PrintJarMainClass.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/PrintJarMainClass.java
@@ -41,7 +41,7 @@ public class PrintJarMainClass {
         if (manifest != null) {
           String value = manifest.getMainAttributes().getValue("Main-Class");
           if (value != null) {
-            System.out.println(value.replaceAll("/", "."));
+            System.out.println(value.replace("/", "."));
             return;
           }
         }

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyCommitter.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/mapred/CopyCommitter.java
@@ -134,7 +134,7 @@ public class CopyCommitter extends FileOutputCommitter {
                                       String jobId) throws IOException {
 
     FileStatus[] tempFiles = targetFS.globStatus(
-        new Path(targetWorkPath, ".distcp.tmp." + jobId.replaceAll("job","attempt") + "*"));
+        new Path(targetWorkPath, ".distcp.tmp." + jobId.replace("job","attempt") + "*"));
 
     if (tempFiles != null && tempFiles.length > 0) {
       for (FileStatus file : tempFiles) {

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/state/Graph.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/state/Graph.java
@@ -138,7 +138,7 @@ public class Graph {
   private static String wrapSafeString(String label) {
     if (label.indexOf(',') >= 0) {
       if (label.length()>14) {
-        label = label.replaceAll(",", ",\n");
+        label = label.replace(",", ",\n");
       }
     }
     label = "\"" + StringEscapeUtils.escapeJava(label) + "\"";


### PR DESCRIPTION
[HADOOP-16267](https://issues.apache.org/jira/browse/HADOOP-16267) instances of replaceAll() which do not use regex to replace()